### PR TITLE
Extend device permissions to make gamepads work

### DIFF
--- a/io.github.theforceengine.tfe.yml
+++ b/io.github.theforceengine.tfe.yml
@@ -7,8 +7,8 @@ rename-desktop-file: TheForceEngine.desktop
 rename-icon: TheForceEngine
 
 finish-args:
-  # hardware 3D
-  - --device=dri
+  # hardware 3D and controller access
+  - --device=all
   # X11 + XShm access
   - --share=ipc
   - --socket=x11


### PR DESCRIPTION
A user reported [over on the TFE ticket for the Flatpak distribution](https://github.com/luciusDXL/TheForceEngine/issues/268#issuecomment-1960163198) that game controllers won't work with the TFE Flatpak without overriding the devices permission. As this is really a feature that should work out of the box, we should extend this so users can use gamepads without needing to manually override it.