### PR TITLE
AppSteam improvements

### DIFF
--- a/io.github.theforceengine.tfe.metainfo.xml
+++ b/io.github.theforceengine.tfe.metainfo.xml
@@ -2,47 +2,94 @@
 <component type="desktop-application">
   <id type="desktop">io.github.theforceengine.tfe</id>
   <name>The Force Engine</name>
-  <developer_name>The Force Engine Contributors</developer_name>
-  <summary>Modern cross-platform port of Star Wars: Dark Forces with mod support</summary>
+  <developer id="theforceengine.github.io">
+    <name>“The Force Engine” Contributors</name>
+    <name xml:lang="de">Die Mitwirkenden an „The Force Engine“</name>
+    <name xml:lang="pl">Współautorzy „The Force Engine”</name>
+    <url type="homepage">https://theforceengine.github.io</url>
+  </developer>
+  <summary>A modern cross&#x2011;platform port of “STAR WARS: Dark Forces” with mod support</summary>
+  <summary xml:lang="de">Eine moderne Plattformen übergreifende Portierung von „STAR WARS: Dark Forces“ mit Unterstützung für Modifikationen</summary>
+  <summary xml:lang="pl">Nowoczesna wieloplatformowa konwersja „STAR WARS: Dark Forces” z obsługą modyfikacji</summary>
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>GPL-2.0</project_license>
   <launchable type="desktop-id">io.github.theforceengine.tfe.desktop</launchable>
-  <url type="homepage">https://theforceengine.github.io/</url>
+  <url type="homepage">https://theforceengine.github.io</url>
+  <url type="bugtracker">https://github.com/luciusDXL/TheForceEngine/issues</url>
+  <url type="help">https://theforceengine.github.io/Documentation.html</url>
+  <url type="vcs-browser">https://github.com/luciusDXL/TheForceEngine</url>
   <description>
-      <p>The Force Engine is a modernised, reverse engineered port of the Jedi Engine used in Star Wars: Dark Forces and Outlaws. Currently, only Dark Forces is supported but there are already many technical and quality-of-life improvements:</p>
-      <ul>
-          <li>Controller support (except in menus)</li>
-          <li>Support for mouselook like in modern first-person shooters</li>
-          <li>Complete input remapping for in-game controls</li>
-          <li>Widescreen and high-resolution support</li>
-          <li>Texture filtering and bloom effects on light sources</li>
-          <li>Subtitles for dialog (including in-game incidental dialog)</li>
-          <li>Closed captioning for important audio cues in the game</li>
-          <li>Translation support for subtitles/captions</li>
-          <li>A built-in mod loader</li>
-      </ul>
-    <p>Future plans include built-in tools for creating mods and maps for the games as well as Outlaws support.</p>
+    <p>“The Force Engine” is a modernised, reverse engineered port of the “Jedi Engine” used in “STAR WARS: Dark Forces” and “Outlaws”. Currently, only “STAR WARS: Dark Forces” is supported but there are already many technical and quality&#x2011;of&#x2011;life improvements:</p>
+    <p xml:lang="de">„The Force Engine“ ist eine modernisierte, rekonstruierte Portierung der in „STAR WARS: Dark Forces“ und „Outlaws“ verwendeten „Jedi Engine“. Derzeit wird ausschließlich „STAR WARS: Dark Forces“ unterstützt, aber es gibt bereits viele technische und das Leben erleichternde Verbesserungen:</p>
+    <p xml:lang="en-US">“The Force Engine” is a modernized, reverse engineered port of the “Jedi Engine” used in “STAR WARS: Dark Forces” and “Outlaws”. Currently, only “STAR WARS: Dark Forces” is supported but there are already many technical and quality&#x2011;of&#x2011;life improvements:</p>
+    <p xml:lang="pl">„The Force Engine”, to unowocześniona konwersja, odwrotnie inżynierowanego „Jedi Engine”, który wykorzystywano do „STAR WARS: Dark Forces” i „Outlaws”. Na ten czas, wyłącznie „STAR WARS: Dark Forces” jest obsługiwane, lecz istnieje już wiele technicznych i życie ułatwiających ulepszeń:</p>
+    <ul>
+      <li>Controller support (except in menus)</li>
+      <li>Support for mouselook like in modern first&#x2011;person shooters</li>
+      <li>Complete input remapping for in&#x2011;game controls</li>
+      <li>Widescreen and high&#x2011;resolution support</li>
+      <li>Texture filtering and bloom effects on light sources</li>
+      <li>Subtitles for dialog (including in&#x2011;game incidental dialog)</li>
+      <li>Closed captioning for important audio cues in the game</li>
+      <li>Translation support for subtitles/captions</li>
+      <li>A built&#x2011;in mod loader</li>
+    </ul>
+    <ul xml:lang="de">
+      <li>Unterstützung von Steuer&#2011; und Eingabegeräten, ausgenommen in Menüs</li>
+      <li>Unterstützung von Mausumsicht, wie in modernen Ego&#x2011;Shootern</li>
+      <li>Komplett frei belegbare Steuereingaben</li>
+      <li>Unterstützung von Breitbildschirmen und hohen Auflösungen</li>
+      <li>Texturfilter und Glüheffekte auf Lichtquellen</li>
+      <li>Dialoguntertitel, einschließlich situativer Dialoge im Spiel</li>
+      <li>Untertitel bei wichtigen Audiohinweisen im Spiel</li>
+      <li>Unterstützung von übersetzten Untertiteln</li>
+      <li>Integrierter Lader von Modifikationen</li>
+    </ul>
+    <ul xml:lang="pl">
+      <li>Obsługa kontrolerów, za wyjątkiem w menu</li>
+      <li>Obsługa patrzenia myszą, jak w nowoczesnych pierwszoosobowych strzelankach</li>
+      <li>Kompletnie dowolnie przypięcie akcji sterowania gry</li>
+      <li>Obsługa szerokich ekranów i wysokich rozdzielczości</li>
+      <li>Filtr tekstur i efekty lśnienia źródeł światła</li>
+      <li>Podtytuły dialogów, w tym okolicznościowych</li>
+      <li>Napisy przy ważnych sygnałach dźwiękowych w grze</li>
+      <li>Obsługa przetłumaczonych podtytułów i napisów</li>
+      <li>Wbudowany ładownik modyfikacji</li>
+    </ul>
+    <p>Future plans include built&#x2011;in tools for creating mods and maps for the games as well as Outlaws support.</p>
+    <p xml:lang="de">Zukünftige Pläne beinhalten Werkzeuge zur Erstellung von Modifikationen und Karten für Spiele, sowie die Unterstützung von „Outlaws“.</p>
+    <p xml:lang="pl">Przyszłe plany zawierają narzędzia tworzenia modyfikacji i map do gier, jak i obsługę „Outlaws”.</p>
   </description>
   <screenshots>
     <screenshot type="default">
       <image type="source">https://theforceengine.github.io/screenshots/media1.jpg</image>
-      <caption>"Retro" mode: 4:3 aspect ratio and original game resolution, scaled up to modern full screen sizes</caption>
+      <caption>“Retro” mode: 4:3 aspect ratio and original game resolution, scaled up to modern full screen sizes</caption>
+      <caption xml:lang="de">Der „Retro&#x2011;Modus“ im 4:3&#x2011;Seitenverhältnis und Originalspielauflösung hoch skaliert auf moderne Vollbildgrößen</caption>
+      <caption xml:lang="pl">Tryb „Retro”, stosunek stron 4 do 3 i oryginalna rozdzielczość gry, przeskalowany na nowoczesne pełnoekranowe rozmiary</caption>
     </screenshot>
     <screenshot>
       <image type="source">https://theforceengine.github.io/screenshots/media3.jpg</image>
       <caption>The first level in high resolution</caption>
+      <caption xml:lang="de">Die erste Mission in hoher Auflösung</caption>
+      <caption xml:lang="pl">Pierwszy poziom w wysokiej rozdzielczości</caption>
     </screenshot>
     <screenshot>
       <image type="source">https://theforceengine.github.io/screenshots/media7.jpg</image>
-      <caption>Load/Save menus with screenshots, timestamps and custom save game names</caption>
+      <caption>Load/Save menus with screenshots, timestamps, and custom save game names</caption>
+      <caption xml:lang="de">Lade&#x2011; und Speichermenüs mit Bildschirmfotos, Zeitstempeln und beschriftbaren Spielständen</caption>
+      <caption xml:lang="pl">Menu ładowania i zapisywania stanu gry z zrzutami ekranu, datami i o dowolnych nazwach</caption>
     </screenshot>
     <screenshot>
       <image type="source">https://theforceengine.github.io/screenshots/media6.jpg</image>
-      <caption>Animated in-game 3D objects</caption>
+      <caption>Animated in&#x2011;game 3D objects</caption>
+      <caption xml:lang="de">Animierte 3D&#x2011;Objekte im Spiel</caption>
+      <caption xml:lang="pl">W grze animowane obiekty 3D</caption>
     </screenshot>
   </screenshots>
   <categories>
     <category>Game</category>
+    <category>Shooter</category>
+    <category>ActionGame</category>
   </categories>
   <releases>
     <release version="1.09.540" date="2023-09-30"/>
@@ -51,4 +98,17 @@
     <content_attribute id="violence-fantasy">intense</content_attribute>
   </content_rating>
   <update_contact>https://theforceengine.github.io/</update_contact>
+  <supports>
+    <control>gamepad</control>
+  </supports>
+  <recommends>
+    <control>keyboard</control>
+    <control>pointing</control>
+  </recommends>
+  <requires>
+    <internet>offline-only</internet>
+  </requires>
+  <provides>
+    <binary>theforceengine</binary>
+  </provides>
 </component>


### PR DESCRIPTION
* Add `suggests`, `recommends`, `provides`, and `control` elements
* Drop deprecated `developer_name` element in favor of `developer` element
* Add more `url` types
* Sync AppStream’s `categories` with Desktop Entry’s `Categories`
* Add de, en-US, and pl translations