### PR TITLE
Update flatpak build manifest

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,5 @@
 [submodule "shared-modules"]
 	path = shared-modules
 	url = https://github.com/flathub/shared-modules.git
+	shallow = true
+	fetchRecurseSubmodules = true

--- a/io.github.theforceengine.tfe.yml
+++ b/io.github.theforceengine.tfe.yml
@@ -5,6 +5,9 @@ sdk: org.freedesktop.Sdk
 command: io.github.theforceengine.tfe.sh
 rename-desktop-file: TheForceEngine.desktop
 rename-icon: TheForceEngine
+build-options:
+  strip: true
+  no-debuginfo: true
 
 finish-args:
   # hardware 3D and controller access
@@ -15,13 +18,10 @@ finish-args:
   # Audio
   - --socket=pulseaudio
   # Access to the default Steam Dark Forces data directory for native and Flatpak installations
-  - --filesystem=~/.local/share/Steam/steamapps/common/Dark Forces/Game/
-  - --filesystem=~/.var/app/com.valvesoftware.Steam/.local/share/Steam/steamapps/common/Dark Forces/Game/
+  - --filesystem=home/.local/share/Steam/steamapps/common/Dark Forces/Game:ro
+  - --filesystem=home/.var/app/com.valvesoftware.Steam/.local/share/Steam/steamapps/common/Dark Forces/Game:ro
 
 modules:
-  - shared-modules/glu/glu-9.json
-  - shared-modules/glew/glew.json
-
   - name: tfe
     sources:
       - type: git
@@ -44,24 +44,34 @@ modules:
       - type: script
         dest-filename: io.github.theforceengine.tfe.sh
         commands:
-          - # Check for game data
-          - if [[ -z "$TFE_SKIP_DATACHECK" ]] && [[ -z $(find "$XDG_DATA_HOME" -iname dark.gob) ]] && [[ ! -d "$HOME/.local/share/Steam/steamapps/common/Dark Forces/Game/" ]] && [[ ! -d "/.var/app/com.valvesoftware.Steam/.local/share/Steam/steamapps/common/Dark Forces/Game/" ]]; then
-          -     zenity --error --text "<b>Could not find Dark Forces game data</b>\n\n
-                    Please either install Dark Forces via Steam to your default library path
-                    or copy the game data to <tt><b>$XDG_DATA_HOME/</b></tt>."
-                    --ok-label "Close" --width=400
-          - fi
-          - export TFE_DATA_HOME=/app/share/TheForceEngine
-          - exec theforceengine
+          # Check for game data
+          - |
+            set -e
+            if [[ -z "$TFE_SKIP_DATACHECK" ]] && \
+               [[ -z $(find "$XDG_DATA_HOME" -iname 'dark.gob') ]] && \
+               [[ ! -d "$HOME/.local/share/Steam/steamapps/common/Dark Forces/Game/" ]] && \
+               [[ ! -d '/.var/app/com.valvesoftware.Steam/.local/share/Steam/steamapps/common/Dark Forces/Game/' ]]; then
+                zenity --error \
+                       --text "<b>Could not find Dark Forces game data</b>\\n\\nPlease either install Dark Forces via Steam to your default library path or copy the game data to <tt><b>$XDG_DATA_HOME/</b></tt>." \
+                       --ok-label 'Close' \
+                       --no-wrap
+            fi
+            export TFE_DATA_HOME='/app/share/TheForceEngine'
+            exec theforceengine
     buildsystem: cmake-ninja
     config-opts:
       - -DDISABLE_SYSMIDI=ON
     builddir: true
     build-commands:
       # Install launcher script
-      - install -Dm 744 ../io.github.theforceengine.tfe.sh -t /app/bin
-      # Edit and install desktop launcher file
-      - desktop-file-edit --set-key=Exec --set-value=io.github.theforceengine.tfe.sh ../TheForceEngine/TheForceEngine.desktop
-      # Install locally-included appstream metadata file until a TFE release is made that includes it
-      # https://github.com/luciusDXL/TheForceEngine/pull/375
-      - install -Dm 644 ../io.github.theforceengine.tfe.metainfo.xml /app/share/metainfo/io.github.theforceengine.tfe.metainfo.xml
+      - |
+        set -e
+        install -Dm 0755 '../io.github.theforceengine.tfe.sh' -t '/app/bin'
+        # Edit and install desktop launcher file
+        desktop-file-edit --set-key=Exec --set-value='io.github.theforceengine.tfe.sh' '../TheForceEngine/TheForceEngine.desktop'
+        # Install locally-included appstream metadata file until a TFE release is made that includes it
+        # https://github.com/luciusDXL/TheForceEngine/pull/375
+        install -Dm 0644 '../io.github.theforceengine.tfe.metainfo.xml' '/app/share/metainfo/io.github.theforceengine.tfe.metainfo.xml'
+    modules:
+      - shared-modules/glu/glu-9.json
+      - shared-modules/glew/glew.json


### PR DESCRIPTION
* Drop debug symbols from binaries and building a `.Debug` flatpak extension (faster build times & smaller downloads)
* Use `home` in favor of `~` in app import paths
* Make import paths of Steam’s and GOG’s Dark Forces default locations read‑only
* Refactor building of GLU and GLEW dependency modules on branches of the `tfe` root module in order to better reflect their nature as dependencies
* Refactor the wrapper launch script into a block
  * Make the script fail on the first failed shell command
  * Reformat for better readability
  * Replace fixed dialog width with `--no-wrap` option
  * Enclose paths and file names with single (') and double (") quotes where applicable
* Refactor `build-commands` into a single command block instead of separate commands, each spawning a sub‑shell
  * Prefix octals with `0`
  * Add group and everybody execute permission to launch script
  * Enclose paths and file names with single (') and double (") quotes where applicable

For the sake of completeness, configure git submodules as shallow and to be fetched recursively with the root repo