### PR TITLE
Add CodeOwners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @fpiesche @JakeSmarter


### PR DESCRIPTION
@JakeSmarter this will cause you and me to be added as reviewers to any new PRs here by default. Is that acceptable, or should I make it just myself (so that I get a notification when flathubbot creates an update PR)?